### PR TITLE
Hotfix | 전체 모험가 퀘스트 저장 자료구조 변경 - 최민규

### DIFF
--- a/Assets/02.Scripts/02-9. System/PickManager.cs
+++ b/Assets/02.Scripts/02-9. System/PickManager.cs
@@ -6,13 +6,11 @@ using UnityEngine;
 public class PickManager : Singleton<PickManager>
 {
     [SerializeField]
-    private Dictionary<string, Adventurer> _adventurers = new Dictionary<string, Adventurer>();
-    public Dictionary<string, Adventurer> Adventurers { get => _adventurers; set => _adventurers = value; }
-
+    private List<Adventurer> _adventurers = new List<Adventurer>();
+    public List<Adventurer> Adventurers { get => _adventurers; set => _adventurers = value; }
     [SerializeField]
-    private Dictionary<string, Quest> _quests = new Dictionary<string, Quest>();
-    public Dictionary<string, Quest> Quests { get => _quests; set => _quests = value; }
-
+    private List<Quest> _quests = new List<Quest>();
+    public List<Quest> Quests { get => _quests; set => _quests = value; }
     protected override void Awake()
     {
         base.Awake();
@@ -39,7 +37,7 @@ public class PickManager : Singleton<PickManager>
         while (count < _adventurers.Count)
         {
             int randomIndex = UnityEngine.Random.Range(0, _adventurers.Count);
-            Adventurer adventurer = _adventurers.ElementAt(randomIndex).Value;
+            Adventurer adventurer = _adventurers[randomIndex];
             if (adventurer.AdventurerData.AdventurerState == AdventurerStateType.Idle)
             {
                 return adventurer;
@@ -48,6 +46,7 @@ public class PickManager : Singleton<PickManager>
         }
         return null;
     }
+
     private Quest PickQuest()
     {
         if (_quests.Count == 0)
@@ -59,7 +58,7 @@ public class PickManager : Singleton<PickManager>
         while (count < _quests.Count)
         {
             int randomIndex = UnityEngine.Random.Range(0, _quests.Count);
-            Quest quest = _quests.ElementAt(randomIndex).Value;
+            Quest quest = _quests[randomIndex];
             if (!quest.QuestData.IsQuesting)
             {
                 return quest;

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -6,6 +6,7 @@
     "com.unity.ide.visualstudio": "2.0.22",
     "com.unity.inputsystem": "1.13.0",
     "com.unity.multiplayer.center": "1.0.0",
+    "com.unity.recorder": "5.1.2",
     "com.unity.render-pipelines.universal": "17.0.4",
     "com.unity.test-framework": "1.4.6",
     "com.unity.timeline": "1.8.7",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -92,6 +92,15 @@
       },
       "url": "https://packages.unity.com"
     },
+    "com.unity.bindings.openimageio": {
+      "version": "1.0.0",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.collections": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
     "com.unity.burst": {
       "version": "1.8.19",
       "depth": 2,
@@ -111,7 +120,7 @@
     },
     "com.unity.collections": {
       "version": "2.5.1",
-      "depth": 2,
+      "depth": 1,
       "source": "registry",
       "dependencies": {
         "com.unity.burst": "1.8.17",
@@ -187,9 +196,20 @@
     },
     "com.unity.nuget.mono-cecil": {
       "version": "1.11.4",
-      "depth": 3,
+      "depth": 2,
       "source": "registry",
       "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.recorder": {
+      "version": "5.1.2",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.timeline": "1.8.7",
+        "com.unity.collections": "1.2.4",
+        "com.unity.bindings.openimageio": "1.0.0"
+      },
       "url": "https://packages.unity.com"
     },
     "com.unity.render-pipelines.core": {
@@ -264,7 +284,7 @@
     },
     "com.unity.test-framework.performance": {
       "version": "3.0.3",
-      "depth": 3,
+      "depth": 2,
       "source": "registry",
       "dependencies": {
         "com.unity.test-framework": "1.1.31",


### PR DESCRIPTION
### 📝작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
<br/>
기존에 전체 모험가와 퀘스트를 담고 있던 Dictionary는 직렬화가 불가능하여 유니티 에디터 인스펙터 상에서 조회가 불가능했습니다. 이를 고려하여 전체 모험가와 퀘스트를 저장하는 자료구조를 List로 변경하였습니다.

### ⏱️예상 리뷰 시간 : 1m
<br/>

### 📷스크린샷 (선택)
<br/>

### 💬리뷰 요구사항(선택)
