### PR TITLE
Fix | 랜덤스탯 미반영이슈 해결 - 최민규

### DIFF
--- a/Assets/02.Scripts/02-2. Adventurer/Adventurer.cs
+++ b/Assets/02.Scripts/02-2. Adventurer/Adventurer.cs
@@ -18,10 +18,6 @@ public class Adventurer : MonoBehaviour
         InitAdventurerData();
         gameObject.SetActive(false);
     }
-    private void OnEnable()
-    {
-        SetAdventurerData();
-    }
     private void OnDisable()
     {
 
@@ -87,7 +83,7 @@ public class Adventurer : MonoBehaviour
             spritesPair.LDSprite
         );
     }
-    private void SetAdventurerData()
+    public void SetAdventurerData()
     {
         if (_adventurerSO.AdventurerType == AdventurerType.Major || _adventurerSO.AdventurerType == AdventurerType.Dealer)
         {
@@ -106,6 +102,7 @@ public class Adventurer : MonoBehaviour
     }
     private void SetMinorTypeData(MinorASO minorAdventurerSO)
     {
+        Debug.Log("SetMinorTypeData »£√‚");
         _adventurerData.AdventurerType = AdventurerType.Minor;
         _adventurerData.AdventurerName = minorAdventurerSO.AdventurerNameList[Random.Range(0, minorAdventurerSO.AdventurerNameList.Count)];
         _adventurerData.AdventurerClass = minorAdventurerSO.AdventurerClassList[Random.Range(0, minorAdventurerSO.AdventurerClassList.Count)];

--- a/Assets/02.Scripts/02-2. Adventurer/Adventurer.cs
+++ b/Assets/02.Scripts/02-2. Adventurer/Adventurer.cs
@@ -102,7 +102,6 @@ public class Adventurer : MonoBehaviour
     }
     private void SetMinorTypeData(MinorASO minorAdventurerSO)
     {
-        Debug.Log("SetMinorTypeData »£√‚");
         _adventurerData.AdventurerType = AdventurerType.Minor;
         _adventurerData.AdventurerName = minorAdventurerSO.AdventurerNameList[Random.Range(0, minorAdventurerSO.AdventurerNameList.Count)];
         _adventurerData.AdventurerClass = minorAdventurerSO.AdventurerClassList[Random.Range(0, minorAdventurerSO.AdventurerClassList.Count)];

--- a/Assets/02.Scripts/02-8. UI/ProcessUI/CharacterUI.cs
+++ b/Assets/02.Scripts/02-8. UI/ProcessUI/CharacterUI.cs
@@ -48,6 +48,7 @@ public class CharacterUI : MonoBehaviour
         CurrentCharacter.transform.position = _characterActivateTransform.position;
 
         Adventurer adventurer = CurrentCharacter.GetComponent<Adventurer>();
+        adventurer.SetAdventurerData();
         _characterData = adventurer.AdventurerData;
         _adventurerIDCardUI.Initialize(adventurer);
 
@@ -169,22 +170,14 @@ public class CharacterUI : MonoBehaviour
 
     public void ChangeCharacter()
     {
-        Debug.Log("ChangeCharacter 호출");
         _currentCharacter++;
         _dialogIndex = 0;
         HideSpeechBubbleButtonUI();
-        Debug.Log($"{_currentCharacter}, {Characters.Count}");
         CurrentCharacter.SetActive(false);
         if (_currentCharacter < Characters.Count)
         {
-            
-            
             CurrentCharacter = Characters[_currentCharacter];
-
-           
-
             StageShowManager.Instance.MiniCharacter.MiniMove();
-            _adventurerIDCardUI.Initialize(CurrentCharacter.GetComponent<Adventurer>());
         }
         else
         {

--- a/Assets/02.Scripts/02-8. UI/ProcessUI/CharacterUI.cs
+++ b/Assets/02.Scripts/02-8. UI/ProcessUI/CharacterUI.cs
@@ -119,7 +119,6 @@ public class CharacterUI : MonoBehaviour
 
     void ShowDialogueUI(int i)
     {
-        Debug.Log("ShowDialogueUI");
         string prefix = StageShowManager.Instance.ShowCharacter.Prefix;
         if (_dialogIndex < _characterData.DialogSet.Dialog.Count)
         {
@@ -154,7 +153,6 @@ public class CharacterUI : MonoBehaviour
     public void ShowSpeechBubbleButtonUI()
     {
         isCloseable = false;
-        Debug.Log("ShowSpeechBubbleButtonUI");
         ShowSpeechBubbleUI();
         ShowButtonSpeechBubbleUI();
     }
@@ -181,14 +179,10 @@ public class CharacterUI : MonoBehaviour
         }
         else
         {
-            Debug.Log("하루가 끝남");
             _currentCharacter = 0;
             UIManager.Instance.OneCycleStartAndEnd.EndCycle(); 
         }
-        
-        
+
     }
 
-
-    
 }

--- a/Assets/02.Scripts/02-8. UI/Show/AdventurerIDCardUI.cs
+++ b/Assets/02.Scripts/02-8. UI/Show/AdventurerIDCardUI.cs
@@ -81,8 +81,9 @@ public class AdventurerIDCardUI : MonoBehaviour
 
         // 모험가 티어 스프라이트 반영
         _bigAdventurerIDCardContent.AdventurerTierImage.sprite = adventurerTierSprites[(int)data.AdventurerTier];
-
-
+        Debug.Log(" InitializeBigAdventurerIDCardContent호출");
+        Debug.Log($"근력 : {data.CurrentSTR}, 마력 : {data.CurrentMAG}, " +
+            $"통찰력 : {data.CurrentINS}, 손재주 : {data.CurrentDEX}");
         // 모험가 스탯 TMP에 반영
         string leftStatSTRAndMAG = $"근력 {data.CurrentSTR}\n마력 {data.CurrentMAG}";
         _bigAdventurerIDCardContent.LeftStatTMP.text = leftStatSTRAndMAG;

--- a/Assets/02.Scripts/02-8. UI/Show/AdventurerIDCardUI.cs
+++ b/Assets/02.Scripts/02-8. UI/Show/AdventurerIDCardUI.cs
@@ -81,9 +81,6 @@ public class AdventurerIDCardUI : MonoBehaviour
 
         // 모험가 티어 스프라이트 반영
         _bigAdventurerIDCardContent.AdventurerTierImage.sprite = adventurerTierSprites[(int)data.AdventurerTier];
-        Debug.Log(" InitializeBigAdventurerIDCardContent호출");
-        Debug.Log($"근력 : {data.CurrentSTR}, 마력 : {data.CurrentMAG}, " +
-            $"통찰력 : {data.CurrentINS}, 손재주 : {data.CurrentDEX}");
         // 모험가 스탯 TMP에 반영
         string leftStatSTRAndMAG = $"근력 {data.CurrentSTR}\n마력 {data.CurrentMAG}";
         _bigAdventurerIDCardContent.LeftStatTMP.text = leftStatSTRAndMAG;

--- a/Assets/02.Scripts/02-8. UI/Show/ShowCharacter.cs
+++ b/Assets/02.Scripts/02-8. UI/Show/ShowCharacter.cs
@@ -23,23 +23,18 @@ public class ShowCharacter : MonoBehaviour
     private void Start()
     {
         CharacterDisappearShow += () => CharacterDisappear();
-        // Appear();
     }
-
     public void AppearEventSet()
     {
         CharacterAppearShow += UIManager.Instance.CharacterUI.Initialize;
         CharacterAppearShow += () => CharacterAppear();
     }
-    
-
-    //모험가의 애니메이터를 등록함
+    //모험가의 애니메이터를 등록한다.
     public void SetCharacter(Animator characterAnimator, Image characterImage)
     {
         _characterAnimator = characterAnimator;
         _characterImage = characterImage;
     }
-
     public void Appear()
     {
         CharacterAppearShow?.Invoke();
@@ -57,17 +52,13 @@ public class ShowCharacter : MonoBehaviour
             {
                 UIManager.Instance.CharacterUI.ShowSpeechBubbleUIwithPrefix();
             }
-            
         }
-        
-        
     }
     public void Appear(System.Action onComplete)
     {
         CharacterAppearShow += () => CharacterAppear(onComplete);
         CharacterAppearShow?.Invoke();
     }
-
     public void Disappear()
     {
         CharacterDisappearShow?.Invoke();
@@ -77,17 +68,13 @@ public class ShowCharacter : MonoBehaviour
         CharacterDisappearShow += () => CharacterDisappear(onComplete);
         CharacterDisappearShow?.Invoke();
     }
-
     void CharacterAppear(System.Action onComplete = null)
     {
-        Debug.Log("등장");
         UIManager.Instance.CharacterUI.CurrentCharacter.gameObject.SetActive(true);
-        AudioManager.Instance.PlaySFX(_appearSound);
         UIManager.Instance.CharacterUI.CurrentCharacter.GetComponent<Image>().DOFade(1, 1).SetAutoKill(false)
             .OnComplete(()=>onComplete?.Invoke());
-
+        AudioManager.Instance.PlaySFX(_appearSound);
     }
-
     void CharacterDisappear(System.Action onComplete = null)
     {
         UIManager.Instance.CharacterUI.CurrentCharacter.GetComponent<Image>().rectTransform.DOLocalMove(new Vector3(-1200, 0, 0), 2f).SetEase(Ease.InBack)
@@ -96,8 +83,5 @@ public class ShowCharacter : MonoBehaviour
                 UIManager.Instance.CharacterUI.ChangeCharacter();
                 onComplete?.Invoke();
             });
-  
-        
     }
-    
 }


### PR DESCRIPTION
### ※ PR 작성 전 체크리스트 ※
1. 작업하신 브랜치가 최신화되었나요? (behind 커밋이 존재하지 않나요?) 예
2. 추가하신 기능 및 전체 로직이 정상적으로 동작하는 것을 확인하셨나요? (기능 테스트를 완료하셨나요?) 예
3. Scene 내부에 변경사항이 존재한다면, 작업용 Scene에서 추가 혹은 변경한 사항을 메인 Scene에 반영하셨나요? 예
<br/>

### 📝작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.(이미지 첨부 가능)

랜덤스탯이 모험가 카드 UI에 반영되지 않는 문제는, Adventurer 클래스에서의 SetAdventurerData 호출 시점이 모험가카드UI의 Initialize 호출시점보다 뒤에서 호출되어 발생했던 문제였습니다. 
호출 순서를 조정해주고, 이 과정에서 CharacterUI의 ChangeCharcter와 Initialize에서 중복 호출되던 모험가카드UI의 Initialize를 CharacterUI의 Initialize에서만 호출해주도록 변경하였습니다.
추가적으로 CharacterUI에 존재하던 불필요한 로그 출력문을 제거했습니다.

### 📷메인 Scene 변경 내용(선택)
> 작업용 Scene에서 작업하신 내용을 메인 Scene에 반영해주시고, 어떤 내용이 Hierarchy상에 반영되었는지 설명해주세요. <br/>
> 스크린샷도 첨부해주시면 가장 좋습니다.
<br/>

### ⏱️예상 리뷰 시간 : 
<br/>

### 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.<br/>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
