### PR TITLE
Feat | 퀘스트 티어별 등장날짜 제한 - 최민규

### DIFF
--- a/Assets/01.Scenes/UIScene_Main.unity
+++ b/Assets/01.Scenes/UIScene_Main.unity
@@ -14301,7 +14301,7 @@ MonoBehaviour:
   m_HandleRect: {fileID: 1729681286}
   m_Direction: 2
   m_Value: 1.0000005
-  m_Size: 0.7575614
+  m_Size: 0.7575615
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -16601,8 +16601,8 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 935291923}
   m_HandleRect: {fileID: 935291922}
   m_Direction: 2
-  m_Value: 0.9999998
-  m_Size: 0.5208197
+  m_Value: 1.0000001
+  m_Size: 0.5208198
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:

--- a/Assets/02.Scripts/02-3. Quest/Quest.cs
+++ b/Assets/02.Scripts/02-3. Quest/Quest.cs
@@ -53,7 +53,6 @@ public class Quest : MonoBehaviour
         int currentDate = DateManager.Instance.CurrentDate;
 
         SetQuestPowerForClearOnDate(ref currentDate);
-        SetQuestTierAndImageColorOnDate(ref currentDate);
         SetQuestRewardOnDate(ref currentDate);
         SetQuestPenaltyOnDate(ref currentDate);
         SetQuestStateAfterFailOnDate(ref currentDate);

--- a/Assets/02.Scripts/02-8. UI/Show/AdventurerIDCardUI.cs
+++ b/Assets/02.Scripts/02-8. UI/Show/AdventurerIDCardUI.cs
@@ -74,9 +74,8 @@ public class AdventurerIDCardUI : MonoBehaviour
             _bigAdventurerIDCardContent.AdventurerNameTMP.text = "무명의 모험가";
         }
 
-        // 모험가 스프라이트 반영
-        // 현재 구현이 안된 부분
-        // _bigAdventurerIDCardContent.AdventurerImage.sprite = LD 스프라이트에서 마스킹된 모험가 스프라이트;
+        // 모험가 사진 스프라이트 반영
+        _bigAdventurerIDCardContent.AdventurerImage.sprite = data.SpriteLD;
 
 
         // 모험가 티어 스프라이트 반영

--- a/Assets/02.Scripts/02-9. System/PickManager.cs
+++ b/Assets/02.Scripts/02-9. System/PickManager.cs
@@ -11,6 +11,7 @@ public class PickManager : Singleton<PickManager>
     [SerializeField]
     private List<QuestSO> _questDatas = new List<QuestSO>();
     public List<QuestSO> QuestDatas { get => _questDatas; set => _questDatas = value; }
+
     protected override void Awake()
     {
         base.Awake();
@@ -60,7 +61,6 @@ public class PickManager : Singleton<PickManager>
         }
         return null;
     }
-
     private QuestSO PickQuest()
     {
         if (_questDatas.Count == 0)
@@ -68,24 +68,40 @@ public class PickManager : Singleton<PickManager>
             return null;
         }
 
-        List<bool> isChecked = new List<bool>();
+        int currentDate = DateManager.Instance.CurrentDate;
+
+        Dictionary<QuestTierType, (int start, int end)> tierDateRange = new Dictionary<QuestTierType, (int, int)>{
+            { QuestTierType.Green, (1, 8) }, 
+            { QuestTierType.Blue, (7, 13) },
+            { QuestTierType.Yellow, (12, 18) },
+            { QuestTierType.Orange, (17, 25) },
+            { QuestTierType.Red, (24, 30) }};
+
+        List<bool> isChecked = new List<bool>(_questDatas.Count);
         for (int i = 0; i < _questDatas.Count; i++)
         {
             isChecked.Add(false);
         }
+
         int count = 0;
         while (count < _questDatas.Count)
         {
             int randomIndex = UnityEngine.Random.Range(0, _questDatas.Count);
+
+            if (isChecked[randomIndex])
+            {
+                continue;
+            }
+
+            isChecked[randomIndex] = true;
+            count++;
+
             QuestSO questSO = _questDatas[randomIndex];
-            if (!questSO.IsQuesting)
+            var range = tierDateRange[questSO.QuestTier];
+
+            if (!questSO.IsQuesting && range.start <= currentDate && currentDate <= range.end)
             {
                 return questSO;
-            }
-            else if (!isChecked[randomIndex])
-            {
-                isChecked[randomIndex] = true;
-                count++;
             }
         }
         return null;

--- a/Assets/03.Prefabs/Adventurer/Dummy/CharacterMinor.prefab
+++ b/Assets/03.Prefabs/Adventurer/Dummy/CharacterMinor.prefab
@@ -67,9 +67,9 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 0}
+  m_Sprite: {fileID: -2036455193332455462, guid: 2349893ae37fefa428fb3bb65dbf9e2e, type: 3}
   m_Type: 0
-  m_PreserveAspect: 0
+  m_PreserveAspect: 1
   m_FillCenter: 1
   m_FillMethod: 4
   m_FillAmount: 1


### PR DESCRIPTION
### ※ PR 작성 전 체크리스트 ※
1. 작업하신 브랜치가 최신화되었나요? (behind 커밋이 존재하지 않나요?)
2. 추가하신 기능 및 전체 로직이 정상적으로 동작하는 것을 확인하셨나요? (기능 테스트를 완료하셨나요?)
3. Scene 내부에 변경사항이 존재한다면, 작업용 Scene에서 추가 혹은 변경한 사항을 메인 Scene에 반영하셨나요?
<br/>

### 📝작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.(이미지 첨부 가능)

퀘스트 티어별 등장 일차를 제한하는 로직을 PickManager의 PickQuest에 구현했습니다.
퀘스트 티어별 등장 가능 일차는 다음과 같습니다.
Green : 1 ~ 8<br/>
Blue : 7 ~ 13<br/>
Yellow : 12 ~ 18<br/>
Orange : 17 ~ 25<br/>
Red : 24 ~ 30<br/>

추가적으로 모험가 카드에, 현재 방문한 모험가의 LD 스프라이트를 반영하도록 했습니다.


### 📷메인 Scene 변경 내용(선택)
> 작업용 Scene에서 작업하신 내용을 메인 Scene에 반영해주시고, 어떤 내용이 Hierarchy상에 반영되었는지 설명해주세요. <br/>
> 스크린샷도 첨부해주시면 가장 좋습니다.
<br/>
PickManager의 questDatas 리스트 내용물이 누락되어 추가했습니다.

### ⏱️예상 리뷰 시간 : 
<br/>

### 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.<br/>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
