### PR TITLE
Fix | 다이얼로그 사라짐 이슈 해결 - 최민규

### DIFF
--- a/Assets/02.Scripts/02-8. UI/ProcessUI/CharacterUI.cs
+++ b/Assets/02.Scripts/02-8. UI/ProcessUI/CharacterUI.cs
@@ -44,6 +44,7 @@ public class CharacterUI : MonoBehaviour
 
         _characterText.text = "";
         //_characterButton.onClick.AddListener(ShowSpeechBubbleUI);
+        _speechButton.onClick.RemoveAllListeners();
         _speechButton.onClick.AddListener(NextDialogue);
         CurrentCharacter = Characters[_currentCharacter];
         CurrentCharacter.transform.position = _characterActivateTransform.position;


### PR DESCRIPTION
### ※ PR 작성 전 체크리스트 ※
1. 작업하신 브랜치가 최신화되었나요? (behind 커밋이 존재하지 않나요?) 네 
2. 추가하신 기능 및 전체 로직이 정상적으로 동작하는 것을 확인하셨나요? (기능 테스트를 완료하셨나요?) 네
3. Scene 내부에 변경사항이 존재한다면, 작업용 Scene에서 추가 혹은 변경한 사항을 메인 Scene에 반영하셨나요? 네
<br/>

### 📝작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.(이미지 첨부 가능)

다이얼로그의 사라짐 이슈를 해결했습니다.
다이얼로그는 모든 모험가에게 3개씩 할당됩니다.
1번째 방문한 모험가의 경우 정상적으로 3개의 대사가 전부 보여지지만, 
2번째 방문한 모험가의 경우 1개의 대사가 누락되고(2번째 대사 다이얼로그를 클릭하면 다이얼로그가 사라짐), 
3번째 방문한 모험가부터는 최초 1개의 대사만 보여지는 문제(1번째 대사 다이얼로그를 클릭하면 다이얼로그가 사라짐)가 발생했습니다.

버튼리스너쪽 문제일 것 같아 살펴본 결과, speechButton의 온클릭리스너 제거 로직이 존재하지 않았습니다.
CharacterUI의 Initialize 메서드는 매번 모험가가 올때마다 호출되다보니, 버튼 온클릭리스너가 매번 추가되어 한번의 클릭에
모든 대사가 넘어가버리는 문제가 발생했던 것입니다.

따라서 해당 Initialize 메서드 내 speechButton의 온클릭리스너 제거 로직을 추가해줬습니다.


### 📷메인 Scene 변경 내용(선택)
> 작업용 Scene에서 작업하신 내용을 메인 Scene에 반영해주시고, 어떤 내용이 Hierarchy상에 반영되었는지 설명해주세요. <br/>
> 스크린샷도 첨부해주시면 가장 좋습니다.
<br/>
변경 내용은 존재하지 않습니다.

### ⏱️예상 리뷰 시간 : 10s
<br/>

### 💬리뷰 요구사항(선택)
